### PR TITLE
fix undefined variable in setup:upgrade

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -538,6 +538,7 @@ class UpgradeData implements UpgradeDataInterface
                 $storeId
             );
             $this->logger->critical($errorMessage, ['exception' => $e]);
+            $lastUpdatedList = [];
         }
 
         return $lastUpdatedList;


### PR DESCRIPTION
if the call to $this->product->getProductsFromPrintformerApi fails with an exception, the variable $lastUpdatedList is never defined and will fail in the context of php 8.1

corresponding error message on a deploy: 
![image](https://github.com/risscsolutions/printformer-magento-2/assets/2969243/d45fb01e-9399-4a62-8139-646d7cab0ffb)
